### PR TITLE
Changed edown dependency to 0.7

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- erlang -*-
 {erl_opts, [debug_info]}.
-{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", "HEAD"}}]}.
+{deps, [{edown, ".*", {git, "git://github.com/uwiger/edown.git", {tag, "0.7"}}}]}.
 {edoc_opts, [{doclet, edown_doclet},
              {app_default, "http://www.erlang.org/doc/man"},
              {top_level_readme,


### PR DESCRIPTION
While updating riak_core and it's depencies so it would compile on Erlang 18, I found that the edown dependency conflicted with a different library, this solves that.
